### PR TITLE
fix: anchor chrono sunrise/sunset to UTC midnight (#2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fix missing sunrise/twilight events near midnight at timezone boundaries in `chrono` sunrise/sunset APIs.
+- Keep sunrise/sunset bracketing transit on the requested local date even when SPA wraps near UTC midnight.
 
 ## [0.4.4] - 2025-11-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fix missing sunrise/twilight events near midnight at timezone boundaries in `chrono` sunrise/sunset APIs.
+
 ## [0.4.4] - 2025-11-30
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solar-positioning"
-version = "0.4.4"
+version = "0.4.5-dev"
 edition = "2021"
 rust-version = "1.70"
 license = "MIT"
@@ -27,8 +27,8 @@ chrono = { version = "0.4", default-features = false, optional = true }
 libm = { version = "0.2", optional = true }
 
 [dev-dependencies]
-criterion = { version = "0.7", features = ["html_reports"] }
-csv = "1.3"
+criterion = { version = "0.8", features = ["html_reports"] }
+csv = "1.4"
 chrono = { version = "0.4", features = ["clock"] }
 chrono-tz = "0.10"
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ match result {
 }
 ```
 
+Returned event timestamps are in the same timezone as the input `DateTime`, but can fall on the
+previous/next local calendar date when events occur near midnight (e.g., at timezone boundaries or
+for twilights).
+
 For twilight, use `Horizon::CivilTwilight`, `Horizon::NauticalTwilight`, or `Horizon::AstronomicalTwilight`.
 
 ### Examples

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ For multiple coordinates at the same time, calculate time-dependent parts once (
 ```rust
 let time_dependent = spa::spa_time_dependent_parts(datetime, 69.0).unwrap();
 for (lat, lon) in [(48.21, 16.37), (52.52, 13.40)] {
-    let pos = spa::spa_with_time_dependent_parts(&time_dependent, lat, lon, 0.0, None).unwrap();
+    let pos = spa::spa_with_time_dependent_parts(lat, lon, 0.0, None, &time_dependent).unwrap();
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ match result {
 Returned event timestamps are in the same timezone as the input `DateTime`, but can fall on the
 previous/next local calendar date when events occur near midnight (e.g., at timezone boundaries or
 for twilights).
+The UTC calculation day is chosen so that transit lands on the requested local date; sunrise/sunset
+may shift by ±1 day to keep the expected sunrise–transit–sunset order.
 
 For twilight, use `Horizon::CivilTwilight`, `Horizon::NauticalTwilight`, or `Horizon::AstronomicalTwilight`.
 

--- a/scripts/horizons_check.py
+++ b/scripts/horizons_check.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+Helper to fetch rise/transit/set times from JPL Horizons for a given site.
+
+Uses the Horizons JSON API with a configurable step size and standard RTS markers.
+Time zone handling here is simple: a fixed offset in hours added to UTC for display.
+"""
+
+import argparse
+import datetime as dt
+import json
+import sys
+import urllib.parse
+import urllib.request
+
+
+def build_url(lat: float, lon: float, start: str, stop: str, step_minutes: int) -> str:
+    params = {
+        "format": "json",
+        "COMMAND": "'10'",
+        "EPHEM_TYPE": "OBSERVER",
+        "CENTER": "coord@399",
+        "COORD_TYPE": "GEODETIC",
+        "SITE_COORD": f"'{lon},{lat},0'",
+        "START_TIME": f"'{start}'",
+        "STOP_TIME": f"'{stop}'",
+        "STEP_SIZE": f"'{step_minutes} m'",
+        "QUANTITIES": "'4,9,10'",
+    }
+    return "https://ssd.jpl.nasa.gov/api/horizons.api?" + urllib.parse.urlencode(params)
+
+
+def fetch(url: str) -> str:
+    with urllib.request.urlopen(url) as resp:
+        data = resp.read()
+    payload = json.loads(data)
+    if "result" not in payload:
+        raise RuntimeError("Unexpected Horizons response")
+    return payload["result"]
+
+
+def parse_events(result: str) -> dict[str, dt.datetime]:
+    events: dict[str, dt.datetime] = {}
+    in_table = False
+    for line in result.splitlines():
+        if line.startswith("$$SOE"):
+            in_table = True
+            continue
+        if line.startswith("$$EOE"):
+            break
+        if not in_table:
+            continue
+        parts = line.split()
+        if len(parts) < 3:
+            continue
+        date_str, time_str, marker = parts[0], parts[1], parts[2]
+        try:
+            timestamp = dt.datetime.strptime(f"{date_str} {time_str}", "%Y-%b-%d %H:%M")
+        except ValueError:
+            continue
+        if "r" in marker:
+            events.setdefault("rise", timestamp)
+        if "t" in marker:
+            events.setdefault("transit", timestamp)
+        if "s" in marker:
+            events.setdefault("set", timestamp)
+    return events
+
+
+def format_time(ts: dt.datetime, offset_hours: float) -> str:
+    local = ts + dt.timedelta(hours=offset_hours)
+    return f"{ts.isoformat()}Z  | local {local.isoformat()} (offset {offset_hours:+g}h)"
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Fetch sunrise/transit/set from JPL Horizons."
+    )
+    parser.add_argument("--lat", type=float, required=True, help="Latitude in degrees")
+    parser.add_argument(
+        "--lon", type=float, required=True, help="Longitude in degrees (east+)"
+    )
+    parser.add_argument(
+        "--date", required=True, help="UTC date YYYY-MM-DD for the request window start"
+    )
+    parser.add_argument(
+        "--tz-offset",
+        type=float,
+        default=0.0,
+        help="Fixed offset hours to add for display (e.g. +5 or -7). Default: 0 (UTC only).",
+    )
+    parser.add_argument(
+        "--step-min",
+        type=int,
+        default=10,
+        help="Step size in minutes for Horizons table (affects RTS resolution). Default: 10.",
+    )
+    args = parser.parse_args(argv)
+
+    start = f"{args.date} 00:00"
+    # Stop at next UTC midnight so we bracket the local day.
+    stop_dt = dt.datetime.strptime(args.date, "%Y-%m-%d") + dt.timedelta(days=1)
+    stop = stop_dt.strftime("%Y-%m-%d 00:00")
+
+    url = build_url(args.lat, args.lon, start, stop, args.step_min)
+    result = fetch(url)
+    events = parse_events(result)
+
+    if not events:
+        print("No events found in Horizons output", file=sys.stderr)
+        return 1
+
+    print(f"Site: lat={args.lat}, lon={args.lon}, start={start} UTC")
+    for name in ("rise", "transit", "set"):
+        ts = events.get(name)
+        if ts:
+            print(f"{name.capitalize():7}: {format_time(ts, args.tz_offset)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,8 @@
 //!
 //! // Calculate sunrise/sunset for San Francisco
 //! let date = "2026-06-21T00:00:00-07:00".parse::<DateTime<FixedOffset>>().unwrap();
+//! // Note: returned timestamps are in the same timezone as `date`, but can fall on the
+//! // previous/next local calendar date when events occur near midnight.
 //! let result = spa::sunrise_sunset_for_horizon(
 //!     date,
 //!     37.7749,  // San Francisco latitude

--- a/src/spa/mod.rs
+++ b/src/spa/mod.rs
@@ -908,9 +908,11 @@ where
     F: FnMut(NaiveDate) -> Result<(NaiveDate, V)>,
 {
     let mut last = None;
+    let mut last_transit = None;
     for _ in 0..2 {
         let (transit_local_date, value) = compute(utc_date)?;
         last = Some(value);
+        last_transit = Some(transit_local_date);
         if transit_local_date == local_date {
             break;
         }
@@ -922,6 +924,7 @@ where
         };
     }
 
+    debug_assert_eq!(last_transit, Some(local_date));
     Ok((utc_date, last.expect("loop runs at least once")))
 }
 

--- a/tests/sunrise_midnight_boundary.rs
+++ b/tests/sunrise_midnight_boundary.rs
@@ -1,9 +1,9 @@
 use chrono::{DateTime, FixedOffset, NaiveDate};
 use solar_positioning::{spa, time::DeltaT, Horizon, SunriseResult};
 
-// When sunrise/sunset events occur near local midnight, a naive "same-local-date" mapping can
-// skip/duplicate events. The chrono API uses the local calendar date as the SPA UTC day and
-// corrects sunrise when it ends up after transit.
+// When sunrise/sunset events occur near local midnight, a naive UTC-day mapping can
+// skip/duplicate events. The chrono API picks the internal UTC day so that transit lands on the
+// requested local calendar date, and corrects sunrise when it ends up after transit.
 #[test]
 fn sunrise_near_local_midnight_is_not_skipped() {
     let latitude = 49.60139790853522;
@@ -77,4 +77,71 @@ fn sunrise_sunset_multiple_matches_midnight_handling() {
         sunrise.date_naive(),
         NaiveDate::from_ymd_opt(1986, 6, 2).unwrap()
     );
+}
+
+#[test]
+fn sunrise_near_antimeridian_is_not_shifted_to_next_day() {
+    // Regression for timezone offsets near the antimeridian where sunrise can fall late in UTC.
+    let latitude = -9.459488331200241;
+    let longitude = 177.60664224032377;
+
+    let date = "1997-11-01T00:00:00+12:00"
+        .parse::<DateTime<FixedOffset>>()
+        .unwrap();
+    let delta_t = DeltaT::estimate_from_date_like(date).unwrap();
+
+    let result =
+        spa::sunrise_sunset_for_horizon(date, latitude, longitude, delta_t, Horizon::SunriseSunset)
+            .unwrap();
+
+    let (sunrise, transit) = match result {
+        SunriseResult::RegularDay {
+            sunrise, transit, ..
+        } => (sunrise, transit),
+        _ => panic!("expected regular day"),
+    };
+
+    assert!(sunrise < transit, "sunrise={sunrise} transit={transit}");
+    assert_eq!(
+        sunrise.date_naive(),
+        NaiveDate::from_ymd_opt(1997, 11, 1).unwrap()
+    );
+}
+
+#[test]
+fn sunrise_stays_on_local_date_for_plus_five_offset() {
+    let latitude = -29.807961253888443;
+    let longitude = 80.510704531778;
+
+    let date = "2008-10-16T00:00:00+05:00"
+        .parse::<DateTime<FixedOffset>>()
+        .unwrap();
+    let delta_t = DeltaT::estimate_from_date_like(date).unwrap();
+
+    let result =
+        spa::sunrise_sunset_for_horizon(date, latitude, longitude, delta_t, Horizon::SunriseSunset)
+            .unwrap();
+
+    let (sunrise, transit, sunset) = match result {
+        SunriseResult::RegularDay {
+            sunrise,
+            transit,
+            sunset,
+        } => (sunrise, transit, sunset),
+        _ => panic!("expected regular day"),
+    };
+
+    let local_date = date.date_naive();
+    assert_eq!(
+        transit.date_naive(),
+        local_date,
+        "transit={transit} sunrise={sunrise} sunset={sunset}"
+    );
+    assert_eq!(
+        sunrise.date_naive(),
+        local_date,
+        "transit={transit} sunrise={sunrise} sunset={sunset}"
+    );
+    assert!(sunrise < transit, "sunrise={sunrise} transit={transit}");
+    assert!(transit < sunset, "transit={transit} sunset={sunset}");
 }

--- a/tests/sunrise_midnight_boundary.rs
+++ b/tests/sunrise_midnight_boundary.rs
@@ -1,0 +1,80 @@
+use chrono::{DateTime, FixedOffset, NaiveDate};
+use solar_positioning::{spa, time::DeltaT, Horizon, SunriseResult};
+
+// When sunrise/sunset events occur near local midnight, a naive "same-local-date" mapping can
+// skip/duplicate events. The chrono API uses the local calendar date as the SPA UTC day and
+// corrects sunrise when it ends up after transit.
+#[test]
+fn sunrise_near_local_midnight_is_not_skipped() {
+    let latitude = 49.60139790853522;
+    let longitude = 171.01752655220554;
+    let horizon = Horizon::AstronomicalTwilight;
+
+    for day in [1_u32, 2, 3] {
+        let date = format!("1986-06-0{day}T00:00:00+11:00")
+            .parse::<DateTime<FixedOffset>>()
+            .unwrap();
+        let delta_t = DeltaT::estimate_from_date_like(date).unwrap();
+
+        let result =
+            spa::sunrise_sunset_for_horizon(date, latitude, longitude, delta_t, horizon).unwrap();
+
+        let sunrise = match result {
+            SunriseResult::RegularDay { sunrise, .. } => sunrise,
+            _ => panic!("expected regular day"),
+        };
+
+        let minutes_from_local_midnight = sunrise.signed_duration_since(date).num_minutes();
+        assert!(
+            (-60..=60).contains(&minutes_from_local_midnight),
+            "day={day} sunrise={sunrise} minutes_from_midnight={minutes_from_local_midnight}"
+        );
+
+        if day == 3 {
+            assert!(
+                minutes_from_local_midnight < 0,
+                "expected day 3 sunrise to occur before local midnight, got {sunrise}"
+            );
+            assert_eq!(
+                sunrise.date_naive(),
+                NaiveDate::from_ymd_opt(1986, 6, 2).unwrap()
+            );
+        }
+    }
+}
+
+#[test]
+fn sunrise_sunset_multiple_matches_midnight_handling() {
+    let latitude = 49.60139790853522;
+    let longitude = 171.01752655220554;
+    let horizon = Horizon::AstronomicalTwilight;
+
+    let date = "1986-06-03T00:00:00+11:00"
+        .parse::<DateTime<FixedOffset>>()
+        .unwrap();
+    let delta_t = DeltaT::estimate_from_date_like(date).unwrap();
+
+    let results: Vec<_> =
+        spa::sunrise_sunset_multiple(date, latitude, longitude, delta_t, [horizon])
+            .collect::<solar_positioning::Result<Vec<_>>>()
+            .unwrap();
+
+    assert_eq!(results.len(), 1);
+    let (_h, result) = &results[0];
+
+    let sunrise = match result {
+        SunriseResult::RegularDay { sunrise, .. } => *sunrise,
+        _ => panic!("expected regular day"),
+    };
+
+    let minutes_from_local_midnight = sunrise.signed_duration_since(date).num_minutes();
+    assert!(
+        (-60..=60).contains(&minutes_from_local_midnight),
+        "sunrise={sunrise} minutes_from_midnight={minutes_from_local_midnight}"
+    );
+    assert!(minutes_from_local_midnight < 0);
+    assert_eq!(
+        sunrise.date_naive(),
+        NaiveDate::from_ymd_opt(1986, 6, 2).unwrap()
+    );
+}


### PR DESCRIPTION
Run the SPA sunrise/sunset calculation on the correct UTC day anchored at 0 UT, then convert the result back into the caller’s timezone. Fixes #2